### PR TITLE
fix: Make use of musl build of Nushell

### DIFF
--- a/build.nu
+++ b/build.nu
@@ -9,7 +9,7 @@ print $"(ansi green_bold)Gathering images"
 let images = http get https://api.github.com/repos/nushell/nushell/releases | enumerate | each { |arrayEl|
     let release = $arrayEl.item
 
-    let url = ($release.assets | where name ends-with "x86_64-unknown-linux-gnu.tar.gz").browser_download_url.0
+    let url = ($release.assets | where name ends-with "x86_64-unknown-linux-musl.tar.gz").browser_download_url.0
     let version = $release.name
 
     let tags = (


### PR DESCRIPTION
In order for us to support alpine stages, we'll need to use the `musl` build of `nushell`. This gives us a statically compiled version of the program meaning it can run even if libs aren't present in the image. It will continue to work fine in Fedora/Ubunut/etc. since it's statically compiled.